### PR TITLE
修复URL配置的BUG

### DIFF
--- a/demo/django_demo/django_demo/urls.py
+++ b/demo/django_demo/django_demo/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import  url
 
-urlpatterns = ['',
+urlpatterns = [
     url(r'^pc-geetest/register', 'app.views.pcgetcaptcha', name='pcgetcaptcha'),
     url(r'^mobile-geetest/register', 'app.views.mobilegetcaptcha', name='mobilegetcaptcha'),
     url(r'^pc-geetest/validate$', 'app.views.pcvalidate', name='pcvalidate'),


### PR DESCRIPTION
如果带上了“”，Django会报AttributeError。'str' object has no attribute 'resolve'
应该是写法太老或者写法错误。